### PR TITLE
PLAYG-20 Fixing destroy errors

### DIFF
--- a/osbrain/app.py
+++ b/osbrain/app.py
@@ -20,9 +20,8 @@ api = Api(app)
 class WorldRes(Resource):
     
     def get(self):
-        name = 'Emptiness' if not World.get_name() else World.get_name()
-        msg = f'Welcome to {name}! Please look at the [Cloud Run/Debug Locally - Detailed] window'
-        return {'msg': msg}, 200 if World.get_name() else 404
+        if not World.get_name(): return {'msg': 'Welcome to Emptiness'}, 404
+        return {'msg': f'Welcome to {World.get_name()}!'}, 200
     
     def put(self):
         http_code = 201 if not World.get_live_ns() else 200
@@ -33,7 +32,8 @@ class WorldRes(Resource):
 
     def delete(self):
         name = World.get_name()
-        World.destroy_world()   
+        if not name: return {'msg': 'Nothing to destroy here'}, 404  
+        World.destroy_world() 
         return {'msg': f'{name} was destroyed!'}, 200
 
 
@@ -46,7 +46,7 @@ class PushPullRes(Resource):
         if agent.check_alive():
             for i in range(3):
                 agent.get_agent_proxy(ns_name).send('main', f'Hello there! This is {nick}! Message #{i}')
-                time.sleep(3)
+                time.sleep(0.5)
             msg = f'{nick} says:- Please look for messages in the console'
         else:
             msg = f'{nick} says:- Looks like I am dead'

--- a/osbrain/app.py
+++ b/osbrain/app.py
@@ -24,7 +24,7 @@ class WorldRes(Resource):
         return {'msg': f'Welcome to {World.get_name()}!'}, 200
     
     def put(self):
-        http_code = 201 if not World.get_live_ns() else 200
+        http_code = 201 if not World.get_name() else 200
         data = request.get_json()
         World(data['name'])
         msg = f'Welcome to {data["name"]}!'

--- a/osbrain/app.py
+++ b/osbrain/app.py
@@ -40,6 +40,7 @@ class WorldRes(Resource):
 class PushPullRes(Resource):
     
     def get(self):
+        if not World.get_name(): return {'msg': 'Cannot communicate in vacuum'}, 404
         agent = AgentUtils('6uv5UhwyXmnStkYRYFdq')
         nick = agent.get_nick()
         ns_name = agent.get_ns_name()


### PR DESCRIPTION
- [x] **Scenario 1.** If the World was never instantiated and we call destroy_world() a succes message saying the world was destroyed is returned.

- [x] **Scenario 2.** After destroying the World (DELETE on /world), if we call GET /world it answers as if the World was still there, because World class variable World__instance is not empty (it was initialized once already)
- [x] **Scenario 3.** Same case with PUT /world. World__instance is not None (still initialized) and also the firebase client.
- [x] **Scenario 4.** After destroying the World, if we try to GET /pushpull, an error (Could not locate nameserver is triggered) because World.destroy_world() closes all nameservers.
- [x] **Scenario 5.** If we try to destroy the World for a second time an error occurs (same as Scenario 4).